### PR TITLE
Fix for installed version of VBox check on linux:

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -204,7 +204,7 @@ check_virtualbox_linux() {
 	exit 1
     fi
 
-    local ver=$("${vbm}/VBoxManage" --version)
+    local ver=$("${vbm}" --version)
 
     case $ver in
 	5.[0-9].1[2-9]* ) : ;;


### PR DESCRIPTION
removed extra terms from line 207.  Var vbm is a direct path, and not a path to the directory VBoxManage resides in.