### PR TITLE
Fixing VT check for Windows

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -170,7 +170,7 @@ check_gitbash_win() {
 check_virtualbox_win() {
     local ve=$(wmic cpu get VirtualizationFirmwareEnabled | sed -n 2p)
 
-    if [ "$ve" != "TRUE" ]; then
+    if [ "$ve" == "FALSE" ]; then
 	echo "############################################################################"
 	echo "## ERROR: YOU MUST ENABLE VIRTUALIZATION IN YOUR BIOS BEFORE YOU CONTINUE ##"
 	echo "############################################################################"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -169,8 +169,9 @@ check_gitbash_win() {
 
 check_virtualbox_win() {
     local ve=$(wmic cpu get VirtualizationFirmwareEnabled | sed -n 2p)
+    echo "Virtualization Enabled: $ve"
 
-    if [ "$ve" == "FALSE" ]; then
+    if [ "$ve" != TRUE ]; then
 	echo "############################################################################"
 	echo "## ERROR: YOU MUST ENABLE VIRTUALIZATION IN YOUR BIOS BEFORE YOU CONTINUE ##"
 	echo "############################################################################"


### PR DESCRIPTION
Was previously checking against a string when BASH can do a bool check as `wmic cpu get VirtualizationFirmwareEnabled | sed -n 2p` is a boolean command. Changed the check of $ve against a bool of true/false and echos if Virtualization is enabled for debugging.