### PR TITLE
[Fixed] Issue #191: Errors in 'latest' command due to cmake changes

### DIFF
--- a/fasttrack/bin/swgemu
+++ b/fasttrack/bin/swgemu
@@ -973,8 +973,8 @@ server_latest()
     (
         set -xe
         cd "${BUILD_DIR}"
-        git rm -f build/unix/Makefile build/unix/config.h build/unix/config.status || true
-        git checkout HEAD -- Makefile.in aclocal.m4 config.h.in configure src/client/Makefile.in src/client/aclocal.m4 src/client/config.h.in src/client/configure build/unix
+        git rm -f --ignore-unmatch build/unix/Makefile build/unix/config.h build/unix/config.status || true
+        git checkout HEAD -- Makefile.in aclocal.m4 config.h.in configure src/client/Makefile.in src/client/aclocal.m4 src/client/config.h.in src/client/configure build/unix || true
         local have_changes=$(git status --porcelain --untracked-files=no | wc -l)
         if [ $have_changes -gt 0 ]; then
             git stash save "swgemu-latest $(date)"


### PR DESCRIPTION
- Added '--ignore-unmatch' to line 976 to clear the error due to the change of file locations. I could instead change the paths, but probably better to wait until the update is finished.

- Appended ' || true' to the end of line 977 to handle the errors produced when doing git checkout. All these files still exist in the drive paths so I'm uncertain what's causing the errors at this point.

